### PR TITLE
Add collapse all and expand all to the tree control

### DIFF
--- a/ui/sidebar/index.tsx
+++ b/ui/sidebar/index.tsx
@@ -20,7 +20,9 @@ import {
   ZapOff,
   StopCircle,
   FileText,
-  Layers
+  Layers,
+  ChevronDown,
+  ChevronRight
 } from "react-feather";
 import Button from "../components/button";
 import { RunnerStatus } from "../../server/api/runner/status";
@@ -73,7 +75,7 @@ interface Props {
   onShowCoverage: () => void;
 }
 
-export default function TestExplorer({
+export default function TestExplorer ({
   selectedFile,
   workspace,
   onSelectedFileChange,
@@ -112,6 +114,19 @@ export default function TestExplorer({
     showFailedTests,
     items
   );
+
+  const onCollapseAll = () => {
+    const newCollapsedItems = {};
+    files.forEach(file => {
+      if (file.type === "directory" && file.parent) {
+        newCollapsedItems[file.path] = true;
+      }
+    });
+    setCollapsedItems(newCollapsedItems)
+  }
+  const onExpandAll = () => {
+    setCollapsedItems({})
+  }
 
   if (showFailedTests && failedItems.length) {
     files = filterFailure(files);
@@ -214,38 +229,10 @@ export default function TestExplorer({
       <FileHeader mt={4} mb={3}>
         <FilesHeader>Tests</FilesHeader>
         <RightFilesAction>
-          <Tooltip title="Refresh files" position="bottom" size="small">
-            <Button
-              size="sm"
-              minimal
-              onClick={() => {
-                onRefreshFiles();
-              }}
-            >
-              <RefreshCw size={10} />
-            </Button>
-          </Tooltip>
-          {summary && summary.haveCoverageReport && (
-            <Tooltip
-              title="Show coverage report"
-              position="bottom"
-              size="small"
-            >
-              <Button
-                size="sm"
-                minimal={!showCoverage}
-                onClick={() => {
-                  onShowCoverage();
-                }}
-              >
-                <Layers size={10} />
-              </Button>
-            </Tooltip>
-          )}
           {summary && summary.failedTests && summary.failedTests.length > 0 && (
             <Tooltip
               title="Show only failed tests"
-              position="bottom"
+              position="top"
               size="small"
             >
               <Button
@@ -259,6 +246,56 @@ export default function TestExplorer({
               </Button>
             </Tooltip>
           )}
+          {!showFailedTests && (
+            <Tooltip title="Collapse All Tests" position="top" size="small">
+              <Button
+                size="sm"
+                minimal
+                onClick={onCollapseAll}
+              >
+                <ChevronRight size={10} />
+              </Button>
+            </Tooltip>
+          )}
+          {!showFailedTests && (
+            <Tooltip title="Expand All Tests" position="top" size="small">
+              <Button
+                size="sm"
+                minimal
+                onClick={onExpandAll}
+              >
+                <ChevronDown size={10} />
+              </Button>
+            </Tooltip>
+          )}
+          {summary && summary.haveCoverageReport && (
+            <Tooltip
+              title="Show coverage report"
+              position="top"
+              size="small"
+            >
+              <Button
+                size="sm"
+                minimal={!showCoverage}
+                onClick={() => {
+                  onShowCoverage();
+                }}
+              >
+                <Layers size={10} />
+              </Button>
+            </Tooltip>
+          )}
+          <Tooltip title="Refresh files" position="top" size="small">
+            <Button
+              size="sm"
+              minimal
+              onClick={() => {
+                onRefreshFiles();
+              }}
+            >
+              <RefreshCw size={10} />
+            </Button>
+          </Tooltip>
         </RightFilesAction>
       </FileHeader>
       <Tree


### PR DESCRIPTION
I have added two icons to the tree control icon area. The first collapses
all the directories in the tree except the root directory and the other
expands all the directories in the tree.

This makes it much easier to find a test file to work on.
I also put the icons on the right side because that is where the
"show failing tests only" icon appears and it seemed that they were
similar types of operations. Then I realized that the collapse / expand
don't make sense when the show failing test only icon is toggled
so in that case I hide the icons.

And then because the icons vanish and appear, I rearranged their
position to what I thought made more sense.
Refresh: is always present and always in a fixed location on the right
The most important button is show only failed so it shows up on the
left as the first in the list when there are failed tests.
Then the collapse/expand
Then the coverage (which I think is the least likely to be used) and
therefore in the "hardest spot to hit"
#203